### PR TITLE
Work around Z3 context memory leak in SuperC

### DIFF
--- a/src/main/java/edu/kit/varijoern/composers/kbuild/CloseablePresenceConditionManager.java
+++ b/src/main/java/edu/kit/varijoern/composers/kbuild/CloseablePresenceConditionManager.java
@@ -1,0 +1,20 @@
+package edu.kit.varijoern.composers.kbuild;
+
+import superc.core.PresenceConditionManager;
+
+/**
+ * A {@link PresenceConditionManager} that can be can free the {@link com.microsoft.z3.Context} it uses.
+ */
+public class CloseablePresenceConditionManager extends PresenceConditionManager implements AutoCloseable {
+    /**
+     * Creates a new {@link CloseablePresenceConditionManager}.
+     */
+    public CloseablePresenceConditionManager() {
+        super();
+    }
+
+    @Override
+    public void close() {
+        this.ctx.close();
+    }
+}

--- a/src/main/java/edu/kit/varijoern/composers/kbuild/LinePresenceConditionMapper.java
+++ b/src/main/java/edu/kit/varijoern/composers/kbuild/LinePresenceConditionMapper.java
@@ -83,79 +83,82 @@ public class LinePresenceConditionMapper {
             TokenCreator tokenCreator = new CTokenCreator();
             LexerCreator lexerCreator = new CLexerCreator();
             MacroTable macroTable = new MacroTable(tokenCreator);
-            PresenceConditionManager presenceConditionManager = new PresenceConditionManager();
-            ConditionEvaluator conditionEvaluator = new ConditionEvaluator(ExpressionParser.fromRats(),
-                    presenceConditionManager, macroTable);
-            this.preparePreprocessor(inclusionInformation, macroTable, presenceConditionManager, conditionEvaluator,
-                    lexerCreator, tokenCreator, sourcePath);
-            try (ConditionCapturingHeaderFileManager headerFileManager = new ConditionCapturingHeaderFileManager(
-                    new FileReader(filePath.toFile()),
-                    filePath.toFile(),
-                    List.of(),
-                    inclusionInformation.includePaths().stream()
-                            .map(p -> p.isAbsolute() ? p.toString() : sourcePath.resolve(p).toString())
-                            .toList(),
-                    Arrays.asList(Builtins.sysdirs),
-                    lexerCreator,
-                    tokenCreator,
-                    new StopWatch(),
-                    presenceConditionManager
-            )) {
-                headerFileManager.showErrors(false);
-                Preprocessor preprocessor = new Preprocessor(headerFileManager, macroTable, presenceConditionManager,
-                        conditionEvaluator, tokenCreator);
+            try (CloseablePresenceConditionManager presenceConditionManager = new CloseablePresenceConditionManager()) {
+                ConditionEvaluator conditionEvaluator = new ConditionEvaluator(ExpressionParser.fromRats(),
+                        presenceConditionManager, macroTable);
+                this.preparePreprocessor(inclusionInformation, macroTable, presenceConditionManager, conditionEvaluator,
+                        lexerCreator, tokenCreator, sourcePath);
+                try (ConditionCapturingHeaderFileManager headerFileManager = new ConditionCapturingHeaderFileManager(
+                        new FileReader(filePath.toFile()),
+                        filePath.toFile(),
+                        List.of(),
+                        inclusionInformation.includePaths().stream()
+                                .map(p -> p.isAbsolute() ? p.toString() : sourcePath.resolve(p).toString())
+                                .toList(),
+                        Arrays.asList(Builtins.sysdirs),
+                        lexerCreator,
+                        tokenCreator,
+                        new StopWatch(),
+                        presenceConditionManager
+                )) {
+                    headerFileManager.showErrors(false);
+                    Preprocessor preprocessor = new Preprocessor(headerFileManager, macroTable,
+                            presenceConditionManager, conditionEvaluator, tokenCreator);
 
-                // Preprocess the file and collect presence conditions
-                Syntax next;
-                do {
-                    try {
-                        next = preprocessor.next();
-                    } catch (IllegalStateException | Error e) {
-                        // The preprocessor can `throw new Error()` when it encounters an internal error. If a subclass
-                        // of `Error` is caught, it was not thrown by the preprocessor and something is seriously wrong.
-                        if (e instanceof Error && e.getClass() != Error.class)
-                            throw (Error) e;
-                        LOGGER.atWarn().withThrowable(e).log("Preprocessor encountered an internal error at {}",
-                                headerFileManager.include.getLocation());
-                        break;
+                    // Preprocess the file and collect presence conditions
+                    Syntax next;
+                    do {
+                        try {
+                            next = preprocessor.next();
+                        } catch (IllegalStateException | Error e) {
+                            // The preprocessor can `throw new Error()` when it encounters an internal error. If a
+                            // subclass of `Error` is caught, it was not thrown by the preprocessor and something is
+                            // seriously wrong.
+
+                            if (e instanceof Error && e.getClass() != Error.class)
+                                throw (Error) e;
+                            LOGGER.atWarn().withThrowable(e).log("Preprocessor encountered an internal error at {}",
+                                    headerFileManager.include.getLocation());
+                            break;
+                        }
+                    } while (next.kind() != Syntax.Kind.EOF);
+
+                    // Convert presence conditions to nodes
+                    for (int line = 1; line <= headerFileManager.getLastLine(); line++) {
+                        Optional<PresenceConditionManager.PresenceCondition> conditionOptional
+                                = headerFileManager.getCondition(line);
+                        if (conditionOptional.isEmpty()) {
+                            LOGGER.debug("No presence condition found for line {} in {}", line, filePath);
+                            continue;
+                        }
+
+                        PresenceConditionManager.PresenceCondition condition = conditionOptional.get();
+
+                        Optional<Node> nodeOptional = this.convertBDD(condition.getBDD(), presenceConditionManager);
+                        if (nodeOptional.isEmpty()) {
+                            LOGGER.warn("Could not convert presence condition to node at {}:{}: {}", filePath,
+                                    line, condition);
+                            continue;
+                        }
+
+                        condition.delRef();
+
+                        Node node = nodeOptional.get();
+                        this.convertMacrosToFeatures(node, system);
+                        List<String> unknownFeatures = node.getUniqueLiterals().stream()
+                                .filter(literal -> !(literal instanceof True || literal instanceof False))
+                                .map(literal -> String.valueOf(literal.var))
+                                .filter(var -> !knownFeatures.contains(var))
+                                .toList();
+
+                        if (!unknownFeatures.isEmpty()) {
+                            LOGGER.warn("Unknown features {} in presence condition at {}:{}", unknownFeatures, filePath,
+                                    line);
+                            node = Node.replaceLiterals(node, unknownFeatures, true);
+                        }
+
+                        this.linePresenceConditions.put(line, node);
                     }
-                } while (next.kind() != Syntax.Kind.EOF);
-
-                // Convert presence conditions to nodes
-                for (int line = 1; line <= headerFileManager.getLastLine(); line++) {
-                    Optional<PresenceConditionManager.PresenceCondition> conditionOptional
-                            = headerFileManager.getCondition(line);
-                    if (conditionOptional.isEmpty()) {
-                        LOGGER.debug("No presence condition found for line {} in {}", line, filePath);
-                        continue;
-                    }
-
-                    PresenceConditionManager.PresenceCondition condition = conditionOptional.get();
-
-                    Optional<Node> nodeOptional = this.convertBDD(condition.getBDD(), presenceConditionManager);
-                    if (nodeOptional.isEmpty()) {
-                        LOGGER.warn("Could not convert presence condition to node at {}:{}: {}", filePath,
-                                line, condition);
-                        continue;
-                    }
-
-                    condition.delRef();
-
-                    Node node = nodeOptional.get();
-                    this.convertMacrosToFeatures(node, system);
-                    List<String> unknownFeatures = node.getUniqueLiterals().stream()
-                            .filter(literal -> !(literal instanceof True || literal instanceof False))
-                            .map(literal -> String.valueOf(literal.var))
-                            .filter(var -> !knownFeatures.contains(var))
-                            .toList();
-
-                    if (!unknownFeatures.isEmpty()) {
-                        LOGGER.warn("Unknown features {} in presence condition at {}:{}", unknownFeatures, filePath,
-                                line);
-                        node = Node.replaceLiterals(node, unknownFeatures, true);
-                    }
-
-                    this.linePresenceConditions.put(line, node);
                 }
             }
         }


### PR DESCRIPTION
SuperC creates Z3 `Context`s, which allocate native memory and only release it when they are `close`d. SuperC does not close them, so Vari-Joern now does instead.