### PR TITLE
Make file names of KbuildComposer collision-resistant

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation 'com.beust:jcommander:1.82'
     implementation files('lib/superc.jar', 'lib/xtc.jar', 'lib/javabdd.jar')
     implementation 'com.microsoft.z3:java-jar:4.11.2'
+    implementation 'com.google.guava:guava:33.3.0-jre'
 
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'


### PR DESCRIPTION
KbuildComposer uses suffixes to generate multiple variants of a single source file if it is compiled multiple times using different includes and defines. The suffix used to be a simple hash with a rather high chance of collisions. This PR replaces it with a collision-resistant hash in order to avoid two different variants of a file to map to the same file name in the composer output.