### PR TITLE
KbuildComposer: Set CC for make -in

### DIFF
--- a/src/main/java/edu/kit/varijoern/composers/kbuild/KbuildComposer.java
+++ b/src/main/java/edu/kit/varijoern/composers/kbuild/KbuildComposer.java
@@ -360,6 +360,7 @@ public class KbuildComposer implements Composer {
         LOGGER.info("Determining files to be included");
         ProcessBuilder makeProcessBuilder = new ProcessBuilder("make", "-in")
                 .directory(tmpSourcePath.toFile());
+        makeProcessBuilder.environment().put("CC", "gcc");
         makeProcessBuilder.environment().put("LANG", "C");
         int makeExitCode;
         String output;


### PR DESCRIPTION
When the CC environment variable is set to something other than `gcc`, KbuildComposer fails to detect any compiler calls. Explicitly setting CC to `gcc` fixes this issue.