### PR TITLE
Output config indices instead of full configs

### DIFF
--- a/docs/OutputFormats.md
+++ b/docs/OutputFormats.md
@@ -12,10 +12,11 @@ described in the next section.
 
 ### Product-Based Strategy
 
+- `configurations`: An array of objects, each representing a configuration that was analyzed. Each object contains the
+  feature names as keys and a boolean indicating whether the feature is enabled in the configuration.
 - `individualResults`: An array of objects, each representing the results of the analysis of a single variant.
   Each object has the following fields:
-    - `enabledFeatures`: An object mapping feature names to a boolean indicating whether the feature is enabled in the
-      analyzed combination.
+    - `configuration`: An index into the `configurations` array indicating which configuration was analyzed.
     - `findings`: An array of [Finding objects](#Finding) representing the findings in the analyzed variant.
 - `aggregatedResult`: Analyzing all variants yields a list of findings for each variant. Since a single finding can
   affect multiple variants, the findings are grouped to identify equal findings with each other across variants. This
@@ -23,9 +24,8 @@ described in the next section.
     - `findingAggregations`: An array of objects, each representing the aggregation of a single finding across all
       analyzed variants. Each object has the following fields:
         - `finding`: A [Finding object](#Finding) representing the finding.
-        - `affectedAnalyzedVariants`: An array of objects representing the variants in which the finding was found.
-          Each object is a mapping from feature names to a boolean indicating whether the feature is enabled in the
-          variant.
+        - `affectedAnalyzedVariants`: An array of indices into the `configurations` array representing the variants
+          in which the finding was found.
         - `evidence`: An array of [SourceLocation](#SourceLocation) objects representing the evidence supporting the
           finding.
         - `possibleConditions`: An array of strings representing the determined presence conditions of the finding. Most

--- a/src/main/java/edu/kit/varijoern/ParallelIterationRunner.java
+++ b/src/main/java/edu/kit/varijoern/ParallelIterationRunner.java
@@ -7,6 +7,8 @@ import edu.kit.varijoern.composers.Composer;
 import edu.kit.varijoern.composers.ComposerConfig;
 import edu.kit.varijoern.composers.ComposerException;
 import edu.kit.varijoern.composers.CompositionInformation;
+import edu.kit.varijoern.samplers.Configuration;
+import edu.kit.varijoern.samplers.SampleTracker;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -18,7 +20,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.*;
 
@@ -118,11 +119,12 @@ public class ParallelIterationRunner {
     /**
      * Runs a single iteration with the given sample.
      *
-     * @param sample the sample to analyze
+     * @param sample        the sample to analyze
+     * @param sampleTracker the {@link SampleTracker} used to track all samples
      * @return the results of the analysis
      * @throws InterruptedException if the runner is interrupted
      */
-    public synchronized Output run(@NotNull List<Map<String, Boolean>> sample)
+    public synchronized Output run(@NotNull List<Configuration> sample, @NotNull SampleTracker sampleTracker)
             throws InterruptedException {
         if (isStopped) {
             throw new IllegalStateException("The runner has been stopped.");
@@ -131,15 +133,15 @@ public class ParallelIterationRunner {
         try {
             int uncachedResults = 0;
             for (int i = 0; i < sample.size(); i++) {
-                Map<String, Boolean> features = sample.get(i);
+                Configuration configuration = sample.get(i);
                 AnalysisResult<?> cachedResult = this.resultAggregator.tryAddResultFromCache(
-                        this.resultCache.getAnalysisResultExtractor(iteration, i));
+                        this.resultCache.getAnalysisResultExtractor(iteration, i, sampleTracker));
                 if (cachedResult != null) {
                     results.add(cachedResult);
                     continue;
                 }
                 uncachedResults++;
-                sampleQueue.put(Message.of(new ComposerInvocation(features,
+                sampleQueue.put(Message.of(new ComposerInvocation(configuration,
                         this.tmpDir.resolve(Path.of(iteration + "-" + i))
                 ), i));
             }
@@ -271,11 +273,11 @@ public class ParallelIterationRunner {
         @Override
         public Message<CompositionInformation> process(ComposerInvocation arguments, int configurationIndex)
                 throws InterruptedException {
-            LOGGER.info("Composing variant with features {}", arguments.features);
+            LOGGER.info("Composing variant with configuration {}", arguments.configuration);
             try {
                 Files.createDirectories(arguments.destination());
                 CompositionInformation compositionInformation
-                        = this.composer.compose(arguments.features(), arguments.destination(), featureModel);
+                        = this.composer.compose(arguments.configuration(), arguments.destination(), featureModel);
                 return Message.of(compositionInformation, configurationIndex);
             } catch (IOException e) {
                 LOGGER.atError().withThrowable(e).log("An IO error occurred:");
@@ -298,7 +300,7 @@ public class ParallelIterationRunner {
         @Override
         public Message<AnalysisResult<?>> process(CompositionInformation compositionInformation, int configurationIndex)
                 throws InterruptedException {
-            LOGGER.info("Analyzing variant with features {}", compositionInformation.getEnabledFeatures());
+            LOGGER.info("Analyzing variant with configuration {}", compositionInformation.getConfiguration());
 
             try {
                 AnalysisResult<?> result = this.analyzer.analyze(compositionInformation);
@@ -324,7 +326,7 @@ public class ParallelIterationRunner {
         }
     }
 
-    private record ComposerInvocation(@NotNull Map<String, Boolean> features, @NotNull Path destination) {
+    private record ComposerInvocation(@NotNull Configuration configuration, @NotNull Path destination) {
     }
 
     /**

--- a/src/main/java/edu/kit/varijoern/analyzers/AnalysisResult.java
+++ b/src/main/java/edu/kit/varijoern/analyzers/AnalysisResult.java
@@ -1,27 +1,27 @@
 package edu.kit.varijoern.analyzers;
 
+import edu.kit.varijoern.samplers.Configuration;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
-import java.util.Map;
 
 /**
  * Contains information about the weaknesses an analyzer found in a single variant.
  */
 public abstract class AnalysisResult<T extends Finding> {
-    private final @NotNull Map<String, Boolean> enabledFeatures;
+    private final @NotNull Configuration configuration;
 
-    protected AnalysisResult(@NotNull Map<String, Boolean> enabledFeatures) {
-        this.enabledFeatures = Map.copyOf(enabledFeatures);
+    protected AnalysisResult(@NotNull Configuration configuration) {
+        this.configuration = configuration;
     }
 
     /**
-     * Returns a map of feature names to their enabled status at the time of analysis.
+     * Returns the configuration of the variant this result is for.
      *
-     * @return a map of feature names to their enabled status at the time of analysis
+     * @return the configuration of the variant
      */
-    public @NotNull Map<String, Boolean> getEnabledFeatures() {
-        return enabledFeatures;
+    public @NotNull Configuration getConfiguration() {
+        return this.configuration;
     }
 
     /**
@@ -35,7 +35,7 @@ public abstract class AnalysisResult<T extends Finding> {
     public String toString() {
         int numFindings = this.getFindings().size();
         if (numFindings == 1)
-            return String.format("1 finding in variant %s", this.enabledFeatures);
-        return String.format("%d findings in variant %s", numFindings, this.enabledFeatures);
+            return String.format("1 finding in variant %s", this.configuration.enabledFeatures());
+        return String.format("%d findings in variant %s", numFindings, this.configuration.enabledFeatures());
     }
 }

--- a/src/main/java/edu/kit/varijoern/analyzers/FindingAggregation.java
+++ b/src/main/java/edu/kit/varijoern/analyzers/FindingAggregation.java
@@ -2,10 +2,10 @@ package edu.kit.varijoern.analyzers;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import edu.kit.varijoern.composers.sourcemap.SourceLocation;
+import edu.kit.varijoern.samplers.Configuration;
 import org.jetbrains.annotations.NotNull;
 import org.prop4j.Node;
 
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -15,7 +15,7 @@ import java.util.stream.Collectors;
  */
 public class FindingAggregation {
     private final @NotNull Finding finding;
-    private final @NotNull Set<Map<String, Boolean>> affectedAnalyzedVariants;
+    private final @NotNull Set<Configuration> affectedAnalyzedVariants;
     private final @NotNull Set<Node> possibleConditions;
     private final @NotNull Set<SourceLocation> originalEvidenceLocations;
 
@@ -28,7 +28,7 @@ public class FindingAggregation {
      *                                  affected analyzed variants
      * @param originalEvidenceLocations the original source locations of the evidence that caused the finding
      */
-    public FindingAggregation(@NotNull Finding finding, @NotNull Set<Map<String, Boolean>> affectedAnalyzedVariants,
+    public FindingAggregation(@NotNull Finding finding, @NotNull Set<Configuration> affectedAnalyzedVariants,
                               @NotNull Set<Node> possibleConditions,
                               @NotNull Set<SourceLocation> originalEvidenceLocations) {
         this.finding = finding;
@@ -51,7 +51,7 @@ public class FindingAggregation {
      *
      * @return the affected analyzed variants
      */
-    public @NotNull Set<Map<String, Boolean>> getAffectedAnalyzedVariants() {
+    public @NotNull Set<Configuration> getAffectedAnalyzedVariants() {
         return affectedAnalyzedVariants;
     }
 

--- a/src/main/java/edu/kit/varijoern/analyzers/joern/JoernAnalysisResult.java
+++ b/src/main/java/edu/kit/varijoern/analyzers/joern/JoernAnalysisResult.java
@@ -3,10 +3,10 @@ package edu.kit.varijoern.analyzers.joern;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import edu.kit.varijoern.analyzers.AnalysisResult;
+import edu.kit.varijoern.samplers.Configuration;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -18,14 +18,14 @@ public class JoernAnalysisResult extends AnalysisResult<JoernFinding> {
     /**
      * Creates a new {@link JoernAnalysisResult} from a list of findings.
      *
-     * @param findings        the list of findings
-     * @param enabledFeatures a map of feature names to their enabled status at the time of analysis
+     * @param findings      the list of findings
+     * @param configuration the configuration of the variant this result is for
      */
     @JsonCreator
     public JoernAnalysisResult(@NotNull @JsonProperty("findings") List<JoernFinding> findings,
-                               @NotNull @JsonProperty("enabledFeatures") Map<String, Boolean> enabledFeatures) {
+                               @NotNull @JsonProperty("configuration") Configuration configuration) {
         // Check for null because Jackson does not enforce non-nullability
-        super(Objects.requireNonNull(enabledFeatures));
+        super(Objects.requireNonNull(configuration));
         this.findings = Objects.requireNonNull(findings);
     }
 
@@ -45,12 +45,12 @@ public class JoernAnalysisResult extends AnalysisResult<JoernFinding> {
         if (o == null || getClass() != o.getClass()) return false;
         JoernAnalysisResult that = (JoernAnalysisResult) o;
         return Objects.equals(findings, that.findings)
-                && Objects.equals(this.getEnabledFeatures(), that.getEnabledFeatures());
+                && Objects.equals(this.getConfiguration(), that.getConfiguration());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(findings, this.getEnabledFeatures());
+        return Objects.hash(findings, this.getConfiguration());
     }
 
     @Override

--- a/src/main/java/edu/kit/varijoern/analyzers/joern/JoernAnalyzer.java
+++ b/src/main/java/edu/kit/varijoern/analyzers/joern/JoernAnalyzer.java
@@ -81,7 +81,7 @@ public class JoernAnalyzer implements Analyzer {
             findings.addAll(this.parseFindings(outFile, compositionInformation.getPresenceConditionMapper(),
                     compositionInformation.getSourceMap()));
         }
-        JoernAnalysisResult result = new JoernAnalysisResult(findings, compositionInformation.getEnabledFeatures());
+        JoernAnalysisResult result = new JoernAnalysisResult(findings, compositionInformation.getConfiguration());
         if (this.resultAggregator != null) {
             this.resultAggregator.addResult(result);
         }

--- a/src/main/java/edu/kit/varijoern/analyzers/joern/JoernResultAggregator.java
+++ b/src/main/java/edu/kit/varijoern/analyzers/joern/JoernResultAggregator.java
@@ -43,7 +43,7 @@ public class JoernResultAggregator extends ResultAggregator<JoernAnalysisResult,
                     JoernFinding firstFinding = findingPairs.get(0).getValue0();
                     return new FindingAggregation(firstFinding,
                             findingPairs.stream()
-                                    .map(findingPair -> findingPair.getValue1().getEnabledFeatures())
+                                    .map(findingPair -> findingPair.getValue1().getConfiguration())
                                     .collect(Collectors.toSet()),
                             findingPairs.stream()
                                     .map(findingPair -> findingPair.getValue0().getCondition())

--- a/src/main/java/edu/kit/varijoern/caching/DummyResultCache.java
+++ b/src/main/java/edu/kit/varijoern/caching/DummyResultCache.java
@@ -2,6 +2,7 @@ package edu.kit.varijoern.caching;
 
 import de.ovgu.featureide.fm.core.base.IFeatureModel;
 import edu.kit.varijoern.analyzers.AnalysisResult;
+import edu.kit.varijoern.samplers.SampleTracker;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -28,7 +29,8 @@ public class DummyResultCache extends ResultCache {
     }
 
     @Override
-    public <T> @Nullable T getAnalysisResult(int iteration, int configurationIndex, Class<T> type) {
+    public <T> @Nullable T getAnalysisResult(int iteration, int configurationIndex,
+                                             @NotNull SampleTracker sampleTracker, Class<T> type) {
         return null;
     }
 

--- a/src/main/java/edu/kit/varijoern/composers/Composer.java
+++ b/src/main/java/edu/kit/varijoern/composers/Composer.java
@@ -1,11 +1,11 @@
 package edu.kit.varijoern.composers;
 
 import de.ovgu.featureide.fm.core.base.IFeatureModel;
+import edu.kit.varijoern.samplers.Configuration;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Map;
 
 /**
  * Given a list of enabled features, composers generate a source code variant.
@@ -15,16 +15,17 @@ public interface Composer {
      * Runs the composer on the source files given to the {@link Composer} instance. Implementations must not modify the
      * feature model or the source files.
      *
-     * @param features     a map of feature names to their enabled status
-     * @param destination  a {@link Path} to an existing empty directory into which the resulting code should be saved.
-     *                     This path must be absolute.
-     * @param featureModel the feature model of the analyzed system
+     * @param configuration the {@link Configuration} containing the enabled features for which the composer should
+     *                      generate a variant.
+     * @param destination   a {@link Path} to an existing empty directory into which the resulting code should be saved.
+     *                      This path must be absolute.
+     * @param featureModel  the feature model of the analyzed system
      * @return a {@link CompositionInformation} instance containing information about this composer pass
      * @throws ComposerException    if the composer failed due to invalid source code
      * @throws InterruptedException if the current thread is interrupted
      */
     @NotNull
-    CompositionInformation compose(@NotNull Map<String, Boolean> features, @NotNull Path destination,
+    CompositionInformation compose(@NotNull Configuration configuration, @NotNull Path destination,
                                    @NotNull IFeatureModel featureModel)
             throws IOException, ComposerException, InterruptedException;
 }

--- a/src/main/java/edu/kit/varijoern/composers/CompositionInformation.java
+++ b/src/main/java/edu/kit/varijoern/composers/CompositionInformation.java
@@ -2,18 +2,18 @@ package edu.kit.varijoern.composers;
 
 import edu.kit.varijoern.composers.conditionmapping.PresenceConditionMapper;
 import edu.kit.varijoern.composers.sourcemap.SourceMap;
+import edu.kit.varijoern.samplers.Configuration;
 import org.jetbrains.annotations.NotNull;
 
 import java.nio.file.Path;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Contains information about a composer pass, such as the location of the resulting code.
  */
 public class CompositionInformation {
     private final @NotNull Path location;
-    private final @NotNull Map<String, Boolean> enabledFeatures;
+    private final @NotNull Configuration configuration;
     private final @NotNull PresenceConditionMapper presenceConditionMapper;
     private final @NotNull SourceMap sourceMap;
     private final @NotNull List<LanguageInformation> languageInformation;
@@ -23,17 +23,17 @@ public class CompositionInformation {
      *
      * @param location                the location of the composed code. Must be an absolute path.
      *                                See {@link CompositionInformation#getLocation()}.
-     * @param enabledFeatures         a map of feature names to their enabled status at the time of composition
+     * @param configuration           the configuration of the variant the composer should compose
      * @param presenceConditionMapper a {@link PresenceConditionMapper} for this composition result
      * @param sourceMap               a {@link SourceMap} for this composition result
      * @param languageInformation     relevant details about how the languages in the composition should be handled
      */
-    public CompositionInformation(@NotNull Path location, @NotNull Map<String, Boolean> enabledFeatures,
+    public CompositionInformation(@NotNull Path location, @NotNull Configuration configuration,
                                   @NotNull PresenceConditionMapper presenceConditionMapper,
                                   @NotNull SourceMap sourceMap,
                                   @NotNull List<LanguageInformation> languageInformation) {
         this.location = location;
-        this.enabledFeatures = enabledFeatures;
+        this.configuration = configuration;
         this.presenceConditionMapper = presenceConditionMapper;
         this.sourceMap = sourceMap;
         this.languageInformation = languageInformation;
@@ -50,12 +50,12 @@ public class CompositionInformation {
     }
 
     /**
-     * Returns a map of feature names to their enabled status at the time of composition.
+     * Returns the configuration of the variant the composer should compose.
      *
-     * @return a map of feature names to their enabled status at the time of composition
+     * @return the configuration of the variant the composer should compose
      */
-    public @NotNull Map<String, Boolean> getEnabledFeatures() {
-        return this.enabledFeatures;
+    public @NotNull Configuration getConfiguration() {
+        return this.configuration;
     }
 
     /**

--- a/src/main/java/edu/kit/varijoern/composers/antenna/AntennaComposer.java
+++ b/src/main/java/edu/kit/varijoern/composers/antenna/AntennaComposer.java
@@ -8,6 +8,7 @@ import edu.kit.varijoern.composers.ComposerException;
 import edu.kit.varijoern.composers.CompositionInformation;
 import edu.kit.varijoern.composers.GenericLanguageInformation;
 import edu.kit.varijoern.composers.sourcemap.IdentitySourceMap;
+import edu.kit.varijoern.samplers.Configuration;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
@@ -44,11 +45,11 @@ public class AntennaComposer implements Composer {
     }
 
     @Override
-    public @NotNull CompositionInformation compose(@NotNull Map<String, Boolean> features, @NotNull Path destination,
+    public @NotNull CompositionInformation compose(@NotNull Configuration configuration, @NotNull Path destination,
                                                    @NotNull IFeatureModel featureModel)
             throws IOException, ComposerException {
         LOGGER.info("Running Antenna composer");
-        List<String> enabledFeatures = features.entrySet().stream()
+        List<String> enabledFeatures = configuration.enabledFeatures().entrySet().stream()
                 .filter(Map.Entry::getValue)
                 .map(Map.Entry::getKey)
                 .toList();
@@ -95,7 +96,7 @@ public class AntennaComposer implements Composer {
 
         return new CompositionInformation(
                 destination,
-                features,
+                configuration,
                 presenceConditionMapper,
                 new IdentitySourceMap(),
                 List.of(new GenericLanguageInformation())

--- a/src/main/java/edu/kit/varijoern/composers/kconfig/KconfigComposer.java
+++ b/src/main/java/edu/kit/varijoern/composers/kconfig/KconfigComposer.java
@@ -14,6 +14,7 @@ import edu.kit.varijoern.composers.kconfig.subjects.BusyboxStrategy;
 import edu.kit.varijoern.composers.kconfig.subjects.ComposerStrategy;
 import edu.kit.varijoern.composers.kconfig.subjects.ComposerStrategyFactory;
 import edu.kit.varijoern.composers.sourcemap.SourceMap;
+import edu.kit.varijoern.samplers.Configuration;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.logging.log4j.LogManager;
@@ -149,12 +150,12 @@ public class KconfigComposer implements Composer {
     }
 
     @Override
-    public @NotNull CompositionInformation compose(@NotNull Map<String, Boolean> features, @NotNull Path destination,
+    public @NotNull CompositionInformation compose(@NotNull Configuration configuration, @NotNull Path destination,
                                                    @NotNull IFeatureModel featureModel)
             throws IOException, ComposerException, InterruptedException {
         this.composerStrategy.beforeComposition(featureModel);
 
-        this.generateConfig(features);
+        this.generateConfig(configuration.enabledFeatures());
 
         this.composerStrategy.prepareDependencyDetection();
 
@@ -186,7 +187,7 @@ public class KconfigComposer implements Composer {
 
         return new CompositionInformation(
                 destination,
-                features,
+                configuration,
                 presenceConditionMapper,
                 sourceMap,
                 List.of(languageInformation)

--- a/src/main/java/edu/kit/varijoern/output/JSONOutputFormatter.java
+++ b/src/main/java/edu/kit/varijoern/output/JSONOutputFormatter.java
@@ -3,6 +3,8 @@ package edu.kit.varijoern.output;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import edu.kit.varijoern.samplers.Configuration;
+import edu.kit.varijoern.serialization.JacksonConfigurationToIdSerializer;
 import edu.kit.varijoern.serialization.JacksonNodeSerializer;
 import org.prop4j.Node;
 
@@ -21,6 +23,7 @@ public class JSONOutputFormatter implements OutputFormatter {
         SimpleModule nodeModule = new SimpleModule("NodeSerializer");
         nodeModule.addSerializer(Node.class, new JacksonNodeSerializer());
         nodeModule.addSerializer(Path.class, new PathSerializer());
+        nodeModule.addSerializer(Configuration.class, new JacksonConfigurationToIdSerializer());
         objectMapper.registerModule(nodeModule);
         objectMapper.writerWithDefaultPrettyPrinter().writeValue(outStream, results);
     }

--- a/src/main/java/edu/kit/varijoern/output/OutputData.java
+++ b/src/main/java/edu/kit/varijoern/output/OutputData.java
@@ -4,12 +4,15 @@ import edu.kit.varijoern.analyzers.AggregatedAnalysisResult;
 import edu.kit.varijoern.analyzers.AnalysisResult;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * Contains the results of the analysis. This class is serialized to generate machine-readable output.
  *
+ * @param configurations    the configurations used for the analysis
  * @param individualResults the individual results of the analysis, i.e., the results for each analyzed variant
  * @param aggregatedResult  the aggregated result of the analysis
  */
-public record OutputData(List<AnalysisResult<?>> individualResults, AggregatedAnalysisResult aggregatedResult) {
+public record OutputData(List<Map<String, Boolean>> configurations, List<AnalysisResult<?>> individualResults,
+                         AggregatedAnalysisResult aggregatedResult) {
 }

--- a/src/main/java/edu/kit/varijoern/samplers/Configuration.java
+++ b/src/main/java/edu/kit/varijoern/samplers/Configuration.java
@@ -1,0 +1,17 @@
+package edu.kit.varijoern.samplers;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Map;
+
+/**
+ * Represents a configuration of enabled features for a variant.
+ * This class is used to track configurations and assign them an index for serialization purposes.
+ * The indices are typically managed by a {@link SampleTracker} instance.
+ * @param enabledFeatures a map of feature names to their enabled state, where the keys are feature names
+ *                        and the values are booleans indicating whether the feature is enabled (true) or
+ *                        disabled (false)
+ * @param index the index of this configuration
+ */
+public record Configuration(@NotNull Map<String, Boolean> enabledFeatures, int index) {
+}

--- a/src/main/java/edu/kit/varijoern/samplers/SampleTracker.java
+++ b/src/main/java/edu/kit/varijoern/samplers/SampleTracker.java
@@ -1,0 +1,64 @@
+package edu.kit.varijoern.samplers;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Tracks configurations and assigns IDs to them. These IDs can be used to reference configurations in a more
+ * compact way, especially for serialization purposes.
+ */
+public class SampleTracker {
+    private final @NotNull List<Configuration> configurations = new ArrayList<>();
+    private final @NotNull Map<Map<String, Boolean>, Integer> configurationIndices = new HashMap<>();
+
+    /**
+     * Tracks a configuration and assigns it an ID. If the configuration already exists, it returns the existing
+     * configuration instead of creating a new one.
+     *
+     * @param enabledFeatures a map of feature names to their enabled state, where the keys are feature names
+     *                        and the values are booleans
+     * @return the tracked configuration, which contains the enabled features and its index
+     */
+    public @NotNull Configuration trackConfiguration(@NotNull Map<String, Boolean> enabledFeatures) {
+        if (this.configurationIndices.containsKey(enabledFeatures)) {
+            int index = this.configurationIndices.get(enabledFeatures);
+            return this.configurations.get(index);
+        } else {
+            int index = this.configurations.size();
+            Configuration configuration = new Configuration(enabledFeatures, index);
+            this.configurations.add(configuration);
+            this.configurationIndices.put(enabledFeatures, index);
+            return configuration;
+        }
+    }
+
+    /**
+     * Tracks a list of configurations and assigns IDs to them. See {@link #trackConfiguration(Map)} for more
+     * information.
+     *
+     * @param enabledFeaturesList a list of maps, where each map contains feature names as keys and their enabled state
+     *                            as values
+     * @return a list of tracked configurations, each containing the enabled features and its index
+     */
+    public @NotNull List<Configuration> trackConfigurations(@NotNull List<Map<String, Boolean>> enabledFeaturesList) {
+        return enabledFeaturesList.stream()
+                .map(this::trackConfiguration)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Returns a list of all tracked configurations, each represented as a map of feature names to their enabled state.
+     *
+     * @return a list of maps, where each map contains feature names as keys and their enabled state as values
+     */
+    public @NotNull List<Map<String, Boolean>> getConfigurations() {
+        return this.configurations.stream()
+                .map(Configuration::enabledFeatures)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/edu/kit/varijoern/serialization/JacksonConfigurationDeserializer.java
+++ b/src/main/java/edu/kit/varijoern/serialization/JacksonConfigurationDeserializer.java
@@ -1,0 +1,39 @@
+package edu.kit.varijoern.serialization;
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import edu.kit.varijoern.samplers.Configuration;
+import edu.kit.varijoern.samplers.SampleTracker;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Deserializes a JSON representation of a configuration into a {@link Configuration} object.
+ * This deserializer expects the JSON to be a map where keys are feature names and values are booleans
+ * indicating whether the feature is enabled (true) or disabled (false).
+ * It uses a {@link SampleTracker} to track the configuration and assign it an index.
+ */
+public class JacksonConfigurationDeserializer extends StdDeserializer<Configuration> {
+    public JacksonConfigurationDeserializer() {
+        this(null);
+    }
+
+    public JacksonConfigurationDeserializer(Class<?> vc) {
+        super(vc);
+    }
+
+    @Override
+    public Configuration deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JacksonException {
+        Map<String, Boolean> rawConfiguration = p.readValueAs(new TypeReference<Map<String, Boolean>>() {
+        });
+        if (rawConfiguration == null) {
+            return null;
+        }
+        SampleTracker sampleTracker = (SampleTracker) ctxt.getAttribute("sampleTracker");
+        return sampleTracker.trackConfiguration(rawConfiguration);
+    }
+}

--- a/src/main/java/edu/kit/varijoern/serialization/JacksonConfigurationToIdSerializer.java
+++ b/src/main/java/edu/kit/varijoern/serialization/JacksonConfigurationToIdSerializer.java
@@ -1,0 +1,27 @@
+package edu.kit.varijoern.serialization;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import edu.kit.varijoern.samplers.Configuration;
+import edu.kit.varijoern.samplers.SampleTracker;
+
+import java.io.IOException;
+
+/**
+ * Serializes a {@link Configuration} object to its index, as provided by a {@link SampleTracker}.
+ */
+public class JacksonConfigurationToIdSerializer extends StdSerializer<Configuration> {
+    public JacksonConfigurationToIdSerializer() {
+        this(null);
+    }
+
+    public JacksonConfigurationToIdSerializer(Class<Configuration> t) {
+        super(t);
+    }
+
+    @Override
+    public void serialize(Configuration value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        gen.writeNumber(value.index());
+    }
+}

--- a/src/main/java/edu/kit/varijoern/serialization/JacksonConfigurationToMapSerializer.java
+++ b/src/main/java/edu/kit/varijoern/serialization/JacksonConfigurationToMapSerializer.java
@@ -1,0 +1,28 @@
+package edu.kit.varijoern.serialization;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import edu.kit.varijoern.samplers.Configuration;
+
+import java.io.IOException;
+
+/**
+ * Serializes a {@link Configuration} object to a map of enabled features.
+ * This serializer outputs the enabled features as a JSON object where keys are feature names
+ * and values are booleans indicating whether the feature is enabled (true) or disabled (false).
+ */
+public class JacksonConfigurationToMapSerializer extends StdSerializer<Configuration> {
+    public JacksonConfigurationToMapSerializer() {
+        this(null);
+    }
+
+    public JacksonConfigurationToMapSerializer(Class<Configuration> t) {
+        super(t);
+    }
+
+    @Override
+    public void serialize(Configuration value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        gen.writeObject(value.enabledFeatures());
+    }
+}

--- a/src/test/java/edu/kit/varijoern/ParallelIterationRunnerTest.java
+++ b/src/test/java/edu/kit/varijoern/ParallelIterationRunnerTest.java
@@ -12,6 +12,8 @@ import edu.kit.varijoern.composers.Composer;
 import edu.kit.varijoern.composers.ComposerConfig;
 import edu.kit.varijoern.composers.ComposerException;
 import edu.kit.varijoern.composers.CompositionInformation;
+import edu.kit.varijoern.samplers.Configuration;
+import edu.kit.varijoern.samplers.SampleTracker;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -31,46 +33,56 @@ class ParallelIterationRunnerTest {
 
     @Test
     void pipelineWorks(@TempDir Path tmpDir) throws RunnerException, InterruptedException {
-        List<Map<String, Boolean>> sample = List.of(Map.of("F1", true), Map.of("F2", true));
+        SampleTracker sampleTracker = new SampleTracker();
+        List<Configuration> sample = sampleTracker.trackConfigurations(
+                List.of(Map.of("F1", true), Map.of("F2", true))
+        );
         ParallelIterationRunner runner = new ParallelIterationRunner(2, 1, 1,
                 new ComposerConfigMock(false, false, false, -1), new AnalyzerConfigMock(),
                 new FeatureModel("test"), new DummyResultCache(), tmpDir);
-        ParallelIterationRunner.Output result = runner.run(sample);
+        ParallelIterationRunner.Output result = runner.run(sample, sampleTracker);
         assertNotNull(result.results());
         assertTrue(result.results().stream()
-                .anyMatch(analysisResult -> analysisResult.getEnabledFeatures().containsKey("F1")));
+                .anyMatch(analysisResult -> analysisResult.getConfiguration().enabledFeatures().containsKey("F1")));
         assertTrue(result.results().stream()
-                .anyMatch(analysisResult -> analysisResult.getEnabledFeatures().containsKey("F2")));
+                .anyMatch(analysisResult -> analysisResult.getConfiguration().enabledFeatures().containsKey("F2")));
         runner.stop();
     }
 
     @Test
     void manyConfigurations(@TempDir Path tmpDir) throws RunnerException, InterruptedException {
-        List<Map<String, Boolean>> sample = IntStream.range(0, 100)
-                .mapToObj(i -> Map.of("F" + i, true))
-                .toList();
+        SampleTracker sampleTracker = new SampleTracker();
+        List<Configuration> sample = sampleTracker.trackConfigurations(
+                IntStream.range(0, 100)
+                        .mapToObj(i -> Map.of("F" + i, true))
+                        .toList()
+        );
         ParallelIterationRunner runner = new ParallelIterationRunner(3, 2, 1,
                 new ComposerConfigMock(false, false, false, -1), new AnalyzerConfigMock(),
                 new FeatureModel("test"), new DummyResultCache(), tmpDir);
-        ParallelIterationRunner.Output result = runner.run(sample);
+        ParallelIterationRunner.Output result = runner.run(sample, sampleTracker);
         assertNotNull(result.results());
         for (int i = 0; i < 100; i++) {
             int capturedI = i;
             assertTrue(result.results().stream()
-                    .anyMatch(analysisResult -> analysisResult.getEnabledFeatures().containsKey("F" + capturedI)));
+                    .anyMatch(analysisResult -> analysisResult.getConfiguration().enabledFeatures()
+                            .containsKey("F" + capturedI)));
         }
         runner.stop();
     }
 
     @Test
     void interruption(@TempDir Path tmpDir) throws RunnerException, InterruptedException, BrokenBarrierException {
-        List<Map<String, Boolean>> sample = List.of(Map.of("F1", true), Map.of("F2", true));
+        SampleTracker sampleTracker = new SampleTracker();
+        List<Configuration> sample = sampleTracker.trackConfigurations(
+                List.of(Map.of("F1", true), Map.of("F2", true))
+        );
         ComposerConfigMock composerConfig = new ComposerConfigMock(true, false, true, -1);
         ParallelIterationRunner runner = new ParallelIterationRunner(1, 1, 1, composerConfig,
                 new AnalyzerConfigMock(), new FeatureModel("test"), new DummyResultCache(), tmpDir);
         Thread runnerThread = new Thread(() -> {
             try {
-                runner.run(sample);
+                runner.run(sample, sampleTracker);
             } catch (InterruptedException e) {
                 // expected
             }
@@ -87,13 +99,16 @@ class ParallelIterationRunnerTest {
     @Test
     void ignoredInterruption(@TempDir Path tmpDir)
             throws RunnerException, InterruptedException, BrokenBarrierException {
-        List<Map<String, Boolean>> sample = List.of(Map.of("F1", true), Map.of("F2", true));
+        SampleTracker sampleTracker = new SampleTracker();
+        List<Configuration> sample = sampleTracker.trackConfigurations(
+                List.of(Map.of("F1", true), Map.of("F2", true))
+        );
         ComposerConfigMock composerConfig = new ComposerConfigMock(true, true, true, -1);
         ParallelIterationRunner runner = new ParallelIterationRunner(1, 1, 1, composerConfig,
                 new AnalyzerConfigMock(), new FeatureModel("test"), new DummyResultCache(), tmpDir);
         Thread runnerThread = new Thread(() -> {
             try {
-                runner.run(sample);
+                runner.run(sample, sampleTracker);
             } catch (InterruptedException e) {
                 // expected
             }
@@ -109,9 +124,12 @@ class ParallelIterationRunnerTest {
     @Test
     void usesCache(@TempDir Path tmpDir, @TempDir Path cacheDir)
             throws Exception {
-        List<Map<String, Boolean>> sample = List.of(Map.of("F1", true), Map.of("F1", false));
+        SampleTracker sampleTracker = new SampleTracker();
+        @NotNull List<Configuration> sample = sampleTracker.trackConfigurations(
+                List.of(Map.of("F1", true), Map.of("F1", false))
+        );
         ResultCache cache = new SimpleResultCache(cacheDir);
-        cache.cacheSample(sample, 0);
+        cache.cacheSampleConfigurations(sample, 0);
 
         Function<AnalyzerConfig<?, ?>, ParallelIterationRunner> runnerCreator = (analyzerConfig) -> {
             try {
@@ -124,30 +142,33 @@ class ParallelIterationRunnerTest {
         };
 
         ParallelIterationRunner runner = runnerCreator.apply(new AnalyzerConfigMock());
-        ParallelIterationRunner.Output result = runner.run(sample);
+        ParallelIterationRunner.Output result = runner.run(sample, sampleTracker);
         assertEquals(ParallelIterationRunner.Output.error(Main.STATUS_INTERNAL_ERROR), result);
 
-        EmptyAnalysisResult cachedAnalysisResult = cache.getAnalysisResult(0, 0, EmptyAnalysisResult.class);
+        EmptyAnalysisResult cachedAnalysisResult = cache.getAnalysisResult(0, 0, sampleTracker,
+                EmptyAnalysisResult.class);
         assertNotNull(cachedAnalysisResult);
-        assertEquals(sample.get(0), cachedAnalysisResult.getEnabledFeatures());
-        assertNull(cache.getAnalysisResult(0, 1, EmptyAnalysisResult.class));
+        assertEquals(sample.get(0), cachedAnalysisResult.getConfiguration());
+        assertNull(cache.getAnalysisResult(0, 1, sampleTracker, EmptyAnalysisResult.class));
 
         AnalyzerConfigMock analyzerConfig = new AnalyzerConfigMock();
         runner = runnerCreator.apply(analyzerConfig);
-        result = runner.run(sample);
+        result = runner.run(sample, sampleTracker);
         assertNotNull(result.results());
 
         assertEquals(new HashSet<>(sample), result.results().stream()
-                .map(AnalysisResult::getEnabledFeatures)
+                .map(AnalysisResult::getConfiguration)
                 .collect(Collectors.toSet()));
 
         // Verify that the cached results are correct. In particular, result 0 must not have been overwritten.
-        EmptyAnalysisResult cachedAnalysisResult0 = cache.getAnalysisResult(0, 0, EmptyAnalysisResult.class);
+        EmptyAnalysisResult cachedAnalysisResult0 = cache.getAnalysisResult(0, 0, sampleTracker,
+                EmptyAnalysisResult.class);
         assertNotNull(cachedAnalysisResult0);
-        assertEquals(sample.get(0), cachedAnalysisResult0.getEnabledFeatures());
-        EmptyAnalysisResult cachedAnalysisResult1 = cache.getAnalysisResult(0, 1, EmptyAnalysisResult.class);
+        assertEquals(sample.get(0), cachedAnalysisResult0.getConfiguration());
+        EmptyAnalysisResult cachedAnalysisResult1 = cache.getAnalysisResult(0, 1, sampleTracker,
+                EmptyAnalysisResult.class);
         assertNotNull(cachedAnalysisResult1);
-        assertEquals(sample.get(1), cachedAnalysisResult1.getEnabledFeatures());
+        assertEquals(sample.get(1), cachedAnalysisResult1.getConfiguration());
 
         assertEquals(2, ((EmptyAnalysisResultAggregator) analyzerConfig.getResultAggregator()).getResults().size());
     }
@@ -169,7 +190,7 @@ class ParallelIterationRunnerTest {
         }
 
         @Override
-        public @NotNull CompositionInformation compose(@NotNull Map<String, Boolean> features,
+        public @NotNull CompositionInformation compose(@NotNull Configuration configuration,
                                                        @NotNull Path destination,
                                                        @NotNull IFeatureModel featureModel)
                 throws InterruptedException, ComposerException {
@@ -200,7 +221,7 @@ class ParallelIterationRunnerTest {
             }
             return new CompositionInformation(
                     Path.of("/nowhere"),
-                    features,
+                    configuration,
                     (file, lineNumber) -> Optional.empty(),
                     location -> Optional.empty(),
                     List.of()
@@ -246,7 +267,7 @@ class ParallelIterationRunnerTest {
         @Override
         public @NotNull EmptyAnalysisResult analyze(@NotNull CompositionInformation compositionInformation)
                 throws InterruptedException {
-            EmptyAnalysisResult result = new EmptyAnalysisResult(compositionInformation.getEnabledFeatures());
+            EmptyAnalysisResult result = new EmptyAnalysisResult(compositionInformation.getConfiguration());
             this.resultAggregator.addResult(result);
             return result;
         }
@@ -273,8 +294,8 @@ class ParallelIterationRunnerTest {
 
     private static class EmptyAnalysisResult extends AnalysisResult<Finding> {
         @JsonCreator
-        public EmptyAnalysisResult(@JsonProperty("enabledFeatures") Map<String, Boolean> enabledFeatures) {
-            super(enabledFeatures);
+        public EmptyAnalysisResult(@JsonProperty("configuration") Configuration configuration) {
+            super(configuration);
         }
 
         @Override


### PR DESCRIPTION
These changes significantly reduce the size of Vari-Joerns output for product-based analyses by first printing a list of all analysed configurations and later only referencing these configurations using indices.

This PR might conflict with #69. I think resolving this conflict might be less overwhelming if this is merged before #69.