### PR TITLE
Fix build of kclause/kmax docker image

### DIFF
--- a/src/main/java/edu/kit/varijoern/featuremodel/tortekmax/TorteKmaxFMReader.java
+++ b/src/main/java/edu/kit/varijoern/featuremodel/tortekmax/TorteKmaxFMReader.java
@@ -44,6 +44,10 @@ public class TorteKmaxFMReader implements FeatureModelReader {
             "axtls", "axtls-working-tree-kmax.sh",
             "toybox", "toybox-working-tree-kmax.sh"
     );
+    private static final List<String> EXTRA_FILES = List.of(
+            "kclause-Dockerfile.patch",
+            "kclause-Dockerfile-old.patch"
+    );
     private static final Logger LOGGER = LogManager.getLogger();
     private static final OutputStream STREAM_LOGGER = IoBuilder.forLogger().setLevel(Level.INFO).buildOutputStream();
 
@@ -70,9 +74,10 @@ public class TorteKmaxFMReader implements FeatureModelReader {
     public @NotNull IFeatureModel read(@NotNull Path tmpPath)
             throws IOException, FeatureModelReaderException, InterruptedException {
         LOGGER.info("Reading feature model from Kconfig files in {}", this.sourcePath);
-        String readerScript = ResourcesUtil.getResourceAsString("torte/" + getExperimentScriptName());
-        Path readerScriptPath = tmpPath.resolve(getExperimentScriptName());
-        Files.writeString(readerScriptPath, readerScript, StandardCharsets.UTF_8);
+        this.extractFile(getExperimentScriptName(), tmpPath);
+        for (String extraFile : EXTRA_FILES) {
+            this.extractFile(extraFile, tmpPath);
+        }
 
         Path inputPath = tmpPath.resolve("input");
         Path sourcePath = inputPath.resolve(this.system);
@@ -96,6 +101,12 @@ public class TorteKmaxFMReader implements FeatureModelReader {
             // The source code probably takes a large amount of disk space.
             FileUtils.deleteDirectory(inputPath.toFile());
         }
+    }
+
+    private void extractFile(@NotNull String fileName, @NotNull Path tmpPath) throws IOException {
+        String content = ResourcesUtil.getResourceAsString("torte/" + fileName);
+        Path targetPath = tmpPath.resolve(fileName);
+        Files.writeString(targetPath, content, StandardCharsets.UTF_8);
     }
 
     private void runReader(@NotNull Path tmpPath)

--- a/src/main/resources/torte/axtls-working-tree-kmax.sh
+++ b/src/main/resources/torte/axtls-working-tree-kmax.sh
@@ -17,7 +17,7 @@ experiment-subjects() {
 
 experiment-stages() {
     # Patch the broken Dockerfile until we upgrade torte
-    grep -q "bd3e73239c83ac04e4ea4e3ce12c872475490658" torte/src/docker/kclause/Dockerfile || patch torte/docker/kmax/Dockerfile kclause-Dockerfile-old.patch
+    grep -q "python3-regex" torte/src/docker/kclause/Dockerfile || patch torte/docker/kmax/Dockerfile kclause-Dockerfile-old.patch
 
     push "$INPUT_DIRECTORY"/axtls
     if [ ! -d .git ]; then

--- a/src/main/resources/torte/axtls-working-tree-kmax.sh
+++ b/src/main/resources/torte/axtls-working-tree-kmax.sh
@@ -16,6 +16,9 @@ experiment-subjects() {
 }
 
 experiment-stages() {
+    # Patch the broken Dockerfile until we upgrade torte
+    grep -q "bd3e73239c83ac04e4ea4e3ce12c872475490658" torte/src/docker/kclause/Dockerfile || patch torte/docker/kmax/Dockerfile kclause-Dockerfile-old.patch
+
     push "$INPUT_DIRECTORY"/axtls
     if [ ! -d .git ]; then
         git init

--- a/src/main/resources/torte/busybox-working-tree-kmax.sh
+++ b/src/main/resources/torte/busybox-working-tree-kmax.sh
@@ -17,7 +17,7 @@ experiment-subjects() {
 
 experiment-stages() {
     # Patch the broken Dockerfile until we upgrade torte
-    grep -q "bd3e73239c83ac04e4ea4e3ce12c872475490658" torte/src/docker/kclause/Dockerfile || patch torte/docker/kmax/Dockerfile kclause-Dockerfile-old.patch
+    grep -q "python3-regex" torte/src/docker/kclause/Dockerfile || patch torte/docker/kmax/Dockerfile kclause-Dockerfile-old.patch
 
     push "$INPUT_DIRECTORY"/busybox
     if [ ! -d .git ]; then

--- a/src/main/resources/torte/busybox-working-tree-kmax.sh
+++ b/src/main/resources/torte/busybox-working-tree-kmax.sh
@@ -16,6 +16,9 @@ experiment-subjects() {
 }
 
 experiment-stages() {
+    # Patch the broken Dockerfile until we upgrade torte
+    grep -q "bd3e73239c83ac04e4ea4e3ce12c872475490658" torte/src/docker/kclause/Dockerfile || patch torte/docker/kmax/Dockerfile kclause-Dockerfile-old.patch
+
     push "$INPUT_DIRECTORY"/busybox
     if [ ! -d .git ]; then
         git init

--- a/src/main/resources/torte/fiasco-working-tree-kmax.sh
+++ b/src/main/resources/torte/fiasco-working-tree-kmax.sh
@@ -37,6 +37,9 @@ experiment-subjects() {
 }
 
 experiment-stages() {
+    # Patch the broken Dockerfile until we upgrade torte
+    grep -q "bd3e73239c83ac04e4ea4e3ce12c872475490658" torte/src/docker/kclause/Dockerfile || patch torte/docker/kmax/Dockerfile kclause-Dockerfile-old.patch
+
     push "$INPUT_DIRECTORY"/fiasco
     if [ ! -d .git ]; then
         git init

--- a/src/main/resources/torte/fiasco-working-tree-kmax.sh
+++ b/src/main/resources/torte/fiasco-working-tree-kmax.sh
@@ -38,7 +38,7 @@ experiment-subjects() {
 
 experiment-stages() {
     # Patch the broken Dockerfile until we upgrade torte
-    grep -q "bd3e73239c83ac04e4ea4e3ce12c872475490658" torte/src/docker/kclause/Dockerfile || patch torte/docker/kmax/Dockerfile kclause-Dockerfile-old.patch
+    grep -q "python3-regex" torte/src/docker/kclause/Dockerfile || patch torte/docker/kmax/Dockerfile kclause-Dockerfile-old.patch
 
     push "$INPUT_DIRECTORY"/fiasco
     if [ ! -d .git ]; then

--- a/src/main/resources/torte/kclause-Dockerfile-old.patch
+++ b/src/main/resources/torte/kclause-Dockerfile-old.patch
@@ -1,0 +1,12 @@
+diff --git a/docker/kmax/Dockerfile b/docker/kmax/Dockerfile
+index 72c2fd7..890495c 100644
+--- a/docker/kmax/Dockerfile
++++ b/docker/kmax/Dockerfile
+@@ -5,6 +5,7 @@ RUN apt-get update && apt-get install -y --allow-unauthenticated \
+   git \
+   python3-setuptools \
+   python3-dev \
++  python3-regex \
+   flex \
+   bison \
+   libssl-dev \

--- a/src/main/resources/torte/kclause-Dockerfile.patch
+++ b/src/main/resources/torte/kclause-Dockerfile.patch
@@ -1,0 +1,76 @@
+From b9f512c2ae381eeba9a4a56490fba352e2041517 Mon Sep 17 00:00:00 2001
+From: Elias Kuiter <info@elias-kuiter.de>
+Date: Thu, 21 Aug 2025 13:18:26 +0200
+Subject: [PATCH 1/2] Rename reset command to uninstall with confirmation
+ prompt
+
+- Rename command-reset to command-uninstall in docker.sh and main.sh
+- Add confirmation prompt before removing Docker containers and images
+- Update documentation to reflect new command name
+- Update KClause to newer commit bd3e732
+---
+ src/docker/kclause/Dockerfile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/docker/kclause/Dockerfile b/src/docker/kclause/Dockerfile
+index 0736872..2beb6cd 100644
+--- a/src/docker/kclause/Dockerfile
++++ b/src/docker/kclause/Dockerfile
+@@ -19,7 +19,7 @@ WORKDIR /home
+ # we fix z3 to an older version although we do not need it here, as 4.12.2.0 does not compile correctly
+ RUN git clone https://github.com/paulgazz/kmax.git \
+   && cd kmax \
+-  && git checkout d0fe92db13ca97140385cd39977d937d1ee92d4c \
++  && git checkout bd3e73239c83ac04e4ea4e3ce12c872475490658 \
+   && sed -i 's/z3-solver/z3-solver==4.11.2/' setup.py \
+   && python3 setup.py install
+ 
+-- 
+2.49.1
+
+
+From 4c21da38dd96e9d3d27d5cfbe2456e913bbdf0cc Mon Sep 17 00:00:00 2001
+From: Elias Kuiter <info@elias-kuiter.de>
+Date: Thu, 21 Aug 2025 14:31:50 +0200
+Subject: [PATCH 2/2] updated KMax
+
+---
+ src/docker/kclause/Dockerfile | 11 +++++------
+ 1 file changed, 5 insertions(+), 6 deletions(-)
+
+diff --git a/src/docker/kclause/Dockerfile b/src/docker/kclause/Dockerfile
+index 2beb6cd..1480432 100644
+--- a/src/docker/kclause/Dockerfile
++++ b/src/docker/kclause/Dockerfile
+@@ -1,12 +1,15 @@
+-FROM ubuntu:18.04
++FROM ubuntu:22.04
+ 
+-# install (tested) dependencies of kmax
++# kmax and system (e.g., Linux) dependencies
++ENV DEBIAN_FRONTEND=noninteractive
+ RUN apt-get update && apt-get install -y --allow-unauthenticated \
+   git \
+   python3-setuptools \
++  pipx \
+   python3-dev \
+   flex \
+   bison \
++  bc \
+   libssl-dev \
+   libelf-dev \
+   wget \
+@@ -23,10 +26,6 @@ RUN git clone https://github.com/paulgazz/kmax.git \
+   && sed -i 's/z3-solver/z3-solver==4.11.2/' setup.py \
+   && python3 setup.py install
+ 
+-# install dependencies of analyzed projects
+-RUN apt-get update && apt-get install -y --allow-unauthenticated \
+-  build-essential
+-
+ # copy and set up
+ # - kextractor (which is compiled against the projects' Kconfig implementations)
+ # - IO scripts
+-- 
+2.49.1
+

--- a/src/main/resources/torte/linux-working-tree-kmax.sh
+++ b/src/main/resources/torte/linux-working-tree-kmax.sh
@@ -15,7 +15,7 @@ experiment-subjects() {
 
 experiment-stages() {
     # Patch the broken Dockerfile until we upgrade torte
-    grep -q "bd3e73239c83ac04e4ea4e3ce12c872475490658" torte/src/docker/kclause/Dockerfile || patch torte/docker/kmax/Dockerfile kclause-Dockerfile-old.patch
+    grep -q "python3-regex" torte/src/docker/kclause/Dockerfile || patch torte/docker/kmax/Dockerfile kclause-Dockerfile-old.patch
 
     push "$INPUT_DIRECTORY"/linux
     if [ ! -d .git ]; then

--- a/src/main/resources/torte/linux-working-tree-kmax.sh
+++ b/src/main/resources/torte/linux-working-tree-kmax.sh
@@ -14,6 +14,9 @@ experiment-subjects() {
 }
 
 experiment-stages() {
+    # Patch the broken Dockerfile until we upgrade torte
+    grep -q "bd3e73239c83ac04e4ea4e3ce12c872475490658" torte/src/docker/kclause/Dockerfile || patch torte/docker/kmax/Dockerfile kclause-Dockerfile-old.patch
+
     push "$INPUT_DIRECTORY"/linux
     if [ ! -d .git ]; then
         git init

--- a/src/main/resources/torte/toybox-working-tree-kmax.sh
+++ b/src/main/resources/torte/toybox-working-tree-kmax.sh
@@ -47,6 +47,9 @@ kconfig-post-checkout-hook-toybox(system, revision) {
 }
 
 experiment-stages() {
+    # Patch the broken Dockerfile until we upgrade torte
+    grep -q "bd3e73239c83ac04e4ea4e3ce12c872475490658" torte/src/docker/kclause/Dockerfile || patch torte/src/docker/kclause/Dockerfile kclause-Dockerfile.patch
+
     push "$INPUT_DIRECTORY"/toybox
     sed -Ei 's/source *([^# ]+)/source "\1"/' Config.in
     if [ ! -d .git ]; then


### PR DESCRIPTION
I've added a workaround to make torte's kmax / kclause Dockerfiles build again. For the older version of torte we use, the Dockerfile now installs `python3-regex`, and for the newer version (used only by Toybox), the corresponding patches from https://github.com/ekuiter/torte are applied.