### PR TITLE
Sugarlyzer: Generate Toybox's generated/globals.h

### DIFF
--- a/src/main/python/sugarlyzer/models/program/ProgramSpecification.py
+++ b/src/main/python/sugarlyzer/models/program/ProgramSpecification.py
@@ -112,6 +112,8 @@ class ProgramSpecification(ABC):
         # files are only generated during the build.
         self.create_config_header_and_mapping()
 
+        self.prepare_desugaring()
+
     # TODO Consider removing (Sugarlyzer debt).
     @property
     def oldconfig_location(self):
@@ -358,6 +360,12 @@ class ProgramSpecification(ABC):
         for transformed, original in transformed_to_original_kconfig_files.items():
             os.unlink(transformed)
             os.rename(src=original, dst=transformed)
+
+    def prepare_desugaring(self):
+        """
+        Perform subject-specific preparation steps required before desugaring can be run.
+        """
+        pass
 
     def transform_kconfig_into_kextract_format(self) -> dict[str, str]:
         """


### PR DESCRIPTION
Toybox places struct definitions for its toys in generated/globals.h. The file contains only the structs for those toys enabled in the current configuration. Because Sugarlyzer only runs make on Toybox's default configuration, no structs are present for the toys which are disabled by default, in particular those in toys/pending. These missing structs cause type errors in SugarC and lead to many lines of code missing in the desugared output.

This PR changes Sugarlyzer to generate generated/globals.h itself in order to take all toys into account, regardless of the configuration.