### PR TITLE
Fix Dockerfile patch check

### DIFF
--- a/src/main/resources/torte/axtls-working-tree-kmax.sh
+++ b/src/main/resources/torte/axtls-working-tree-kmax.sh
@@ -17,7 +17,7 @@ experiment-subjects() {
 
 experiment-stages() {
     # Patch the broken Dockerfile until we upgrade torte
-    grep -q "python3-regex" torte/src/docker/kclause/Dockerfile || patch torte/docker/kmax/Dockerfile kclause-Dockerfile-old.patch
+    grep -q "python3-regex" torte/docker/kmax/Dockerfile || patch torte/docker/kmax/Dockerfile kclause-Dockerfile-old.patch
 
     push "$INPUT_DIRECTORY"/axtls
     if [ ! -d .git ]; then

--- a/src/main/resources/torte/busybox-working-tree-kmax.sh
+++ b/src/main/resources/torte/busybox-working-tree-kmax.sh
@@ -17,7 +17,7 @@ experiment-subjects() {
 
 experiment-stages() {
     # Patch the broken Dockerfile until we upgrade torte
-    grep -q "python3-regex" torte/src/docker/kclause/Dockerfile || patch torte/docker/kmax/Dockerfile kclause-Dockerfile-old.patch
+    grep -q "python3-regex" torte/docker/kmax/Dockerfile || patch torte/docker/kmax/Dockerfile kclause-Dockerfile-old.patch
 
     push "$INPUT_DIRECTORY"/busybox
     if [ ! -d .git ]; then

--- a/src/main/resources/torte/fiasco-working-tree-kmax.sh
+++ b/src/main/resources/torte/fiasco-working-tree-kmax.sh
@@ -38,7 +38,7 @@ experiment-subjects() {
 
 experiment-stages() {
     # Patch the broken Dockerfile until we upgrade torte
-    grep -q "python3-regex" torte/src/docker/kclause/Dockerfile || patch torte/docker/kmax/Dockerfile kclause-Dockerfile-old.patch
+    grep -q "python3-regex" torte/docker/kmax/Dockerfile || patch torte/docker/kmax/Dockerfile kclause-Dockerfile-old.patch
 
     push "$INPUT_DIRECTORY"/fiasco
     if [ ! -d .git ]; then

--- a/src/main/resources/torte/linux-working-tree-kmax.sh
+++ b/src/main/resources/torte/linux-working-tree-kmax.sh
@@ -15,7 +15,7 @@ experiment-subjects() {
 
 experiment-stages() {
     # Patch the broken Dockerfile until we upgrade torte
-    grep -q "python3-regex" torte/src/docker/kclause/Dockerfile || patch torte/docker/kmax/Dockerfile kclause-Dockerfile-old.patch
+    grep -q "python3-regex" torte/docker/kmax/Dockerfile || patch torte/docker/kmax/Dockerfile kclause-Dockerfile-old.patch
 
     push "$INPUT_DIRECTORY"/linux
     if [ ! -d .git ]; then


### PR DESCRIPTION
Vari-Joern's torte experiment scripts contain a hack that patches the Dockerfile for torte's kmax image. To avoid patching it unnecessarily, the scripts run grep beforehand. The path passed to the grep commands was wrong in a few cases, leading to an error message in torte's output but no functional bugs.